### PR TITLE
Forward declare some util functions.

### DIFF
--- a/Reflect/inc/Reflect/Core/Util.h
+++ b/Reflect/inc/Reflect/Core/Util.h
@@ -21,6 +21,9 @@ namespace Reflect
 		}
 
 		std::string ValidateTypeName(const std::string& str);
+		static void RemoveChar(std::string& str, const char& c);
+		static void RemoveString(std::string& str, const std::string& remove, bool removeFromback = true);
+		static void RemoveCharAll(std::string& str, const char& c);
 
 		template<typename T>
 		std::string GetTypeName()
@@ -102,7 +105,7 @@ namespace Reflect
 			str.erase(std::remove(str.begin(), str.end(), c), str.end());
 		}
 
-		static void RemoveString(std::string& str, const std::string& remove, bool removeFromback = true)
+		static void RemoveString(std::string& str, const std::string& remove, bool removeFromback)
 		{
 			size_t index = removeFromback ? str.rfind(remove) : str.find(remove);
 			if (index != std::string::npos)


### PR DESCRIPTION
When integrating this in my project with xmake, i got some errors about undeclared functions on Util.h. Since this project uses premake, which relies on VS for building and has probably only been tested with VS, i assume that some combination of VS/MSVC allowed this to work. I forward declared some of the functions used by GetTypeName so that it works.

PS: I've discovered some other kinks here and there so far that i have/can fix for myself. Would like me to open issues or PRs for any of them? Since this looks like an experiment library, i don't want to bombard you with issues or PRs.
